### PR TITLE
Fix missing styles in AppComponent

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,7 +5,7 @@ import { PageComponent } from './page/page.component';
   selector: 'app-root',
   imports: [PageComponent],
   templateUrl: './app.component.html',
-  styleUrl: './app.component.scss'
+  styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
   title = 'docublox';


### PR DESCRIPTION
## Summary
- fix incorrect `styleUrl` attribute in AppComponent

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ng)*

------
https://chatgpt.com/codex/tasks/task_e_68536f60ad088330a57617da8145ad7f