### PR TITLE
Update spec for page component

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -20,10 +20,10 @@ describe('AppComponent', () => {
     expect(app.title).toEqual('docublox');
   });
 
-  it('should render title', () => {
+  it('should render page component', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, docublox');
+    expect(compiled.querySelector('app-page')).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- update app component spec to expect `<app-page>` element

## Testing
- `CHROME_BIN=$(which chromium-browser) npx ng test --watch=false --browsers=ChromeHeadless` *(fails: cannot start ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_6853710eb838833083669df9a43df7c5