### PR TITLE
Rename changePenColour method

### DIFF
--- a/src/app/page/page.component.html
+++ b/src/app/page/page.component.html
@@ -13,7 +13,7 @@
         <input type="range" min="1" max="50" step="1" [(ngModel)]="penSize" (input)="onPenSizeChange(penSize)"
           title="Pen size" style="width:6rem" />
       </div>
-      <input #penColour type="color" style="display:none" [(ngModel)]="penColor" (change)="changePenColour($event)"
+      <input #penColour type="color" style="display:none" [(ngModel)]="penColor" (change)="changePenColor($event)"
         class="colour-swatch" />
       <button (click)="addText()">Add Text</button>
       <div class="handle-wrapper">

--- a/src/app/page/page.component.ts
+++ b/src/app/page/page.component.ts
@@ -477,7 +477,7 @@ export class PageComponent implements AfterViewInit {
     this.drawingPen = true;
   }
 
-  changePenColour(ev: Event) {
+  changePenColor(ev: Event) {
     this.penColor = (ev.target as HTMLInputElement).value;
     if (this.drawingPen) {
       this.tui.setBrush({ width: this.penWidth, color: this.penColor });


### PR DESCRIPTION
## Summary
- rename the changePenColour method to changePenColor
- update the HTML binding to call the renamed method

## Testing
- `npx ng build`
- `npx ng test --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_685370f0bc488330ba8a41773e268498